### PR TITLE
Regex refactoring

### DIFF
--- a/lib/utils/event_name_cleaner.dart
+++ b/lib/utils/event_name_cleaner.dart
@@ -10,7 +10,7 @@ class EventNameCleaner {
   ///
   /// For more, see test/event_name_cleaner_test.dart.
   static final RegExp _pattern = new RegExp(
-      r"(\s+(\(((([23]D)?\s*(dub|orig|spanish)?)|[23]D)\)\s*(\((dub|orig|spanish)?\))?|[23]D))$");
+      r"(\s([23]D$|\(([23]D|dub|orig|spanish).*))");
 
   static String cleanup(String name) {
     var matches = _pattern.allMatches(name);


### PR DESCRIPTION
Made an easier to read regex which can avoid keywords recognition when part of the title (see test/utils/event_name_cleaner_test.dart for examples)