### PR TITLE
The expression here has a type of 'void'

### DIFF
--- a/lib/redux/show/show_middleware.dart
+++ b/lib/redux/show/show_middleware.dart
@@ -30,7 +30,7 @@ class ShowMiddleware extends MiddlewareClass<AppState> {
     }
   }
 
-  void _updateShowDates(dynamic action, NextDispatcher next) {
+  dynamic void _updateShowDates(dynamic action, NextDispatcher next) {
     var now = Clock.getCurrentTime();
     var dates = List.generate(7, (index) => now.add(Duration(days: index)));
 


### PR DESCRIPTION
I have an issue like this : #95 

The expression here has a type of 'void', and therefore cannot be used
For
- OS : Linux 18.04
- Flutter SDK : Channel dev, v0.5.8
- Dart version 2.0.0-dev.69.5.flutter-eab492385c 

So i just try to edit it as a dynamic rather than void, it works but I don't is there any further complication or not
