### PR TITLE
 Add background color to the web page

### DIFF
--- a/web/web/index.html
+++ b/web/web/index.html
@@ -21,6 +21,11 @@
       box-sizing: border-box;
     }
 
+    html,
+    body {
+      background-color: #0e173b;
+    }
+
     body {
       background: url("images/background-image.jpg") no-repeat bottom fixed;
       background-size: cover;

--- a/web/web/index.html
+++ b/web/web/index.html
@@ -21,13 +21,12 @@
       box-sizing: border-box;
     }
 
-    html,
     body {
-      background-color: #0e173b;
-    }
-
-    body {
-      background: url("images/background-image.jpg") no-repeat bottom fixed;
+      background-color: #0f1835;
+      background-image: url("images/background-image.jpg"),
+                        linear-gradient(#1b2f6c, #0f1835);
+      background-position: bottom;
+      background-attachment: fixed;
       background-size: cover;
       opacity: 0;
       transition: opacity 500ms ease;


### PR DESCRIPTION
This pr just tidies the web experience together by preventing the default white background from leaking.

- Show theme color when _overscrolling_ on macOS (rubber-banding)
- Prevents the white splash when entering the site
- Shows linear-gradient on slow connections until the background image is loaded

## Before
<img width="796" alt="screen shot 2018-12-23 at 1 19 27 pm" src="https://user-images.githubusercontent.com/10659247/50383732-57ebbd00-06c2-11e9-990f-f2d0b9bf57a6.png">
<img width="1206" alt="screen shot 2018-12-23 at 2 49 45 pm" src="https://user-images.githubusercontent.com/10659247/50383733-57ebbd00-06c2-11e9-83ed-579d9bc38198.png">

## After
<img width="796" alt="screen shot 2018-12-23 at 1 19 10 pm" src="https://user-images.githubusercontent.com/10659247/50383736-633ee880-06c2-11e9-8768-94c008bc86a9.png">
<img width="1183" alt="screen shot 2018-12-23 at 2 10 09 pm" src="https://user-images.githubusercontent.com/10659247/50383737-63d77f00-06c2-11e9-959b-f14f525d62d2.png">
