### PR TITLE
Use immutable collections from kt.dart

### DIFF
--- a/core/lib/src/models/event.dart
+++ b/core/lib/src/models/event.dart
@@ -1,3 +1,4 @@
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 import 'actor.dart';
@@ -35,19 +36,18 @@ class Event {
   final String ageRating;
   final String ageRatingUrl;
   final String genres;
-  final List<String> directors;
+  final KtList<String> directors;
   final String lengthInMinutes;
   final String shortSynopsis;
   final String synopsis;
   final EventImageData images;
-  final List<ContentDescriptor> contentDescriptors;
-  final List<String> youtubeTrailers;
-  final List<GalleryImage> galleryImages;
+  final KtList<ContentDescriptor> contentDescriptors;
+  final KtList<String> youtubeTrailers;
+  final KtList<GalleryImage> galleryImages;
 
-  String get director =>
-      directors.firstWhere((e) => e != null, orElse: () => null);
-  List<Actor> actors;
-  List<String> get genresSeparated => genres.split(', ');
+  String get director => directors.firstOrNull((e) => e != null);
+  KtList<Actor> actors;
+  KtList<String> get genresSeparated => listFrom(genres.split(', '));
 
   bool get hasSynopsis =>
       (shortSynopsis != null && shortSynopsis.isNotEmpty) ||

--- a/core/lib/src/models/show.dart
+++ b/core/lib/src/models/show.dart
@@ -1,3 +1,5 @@
+import 'package:kt_dart/collection.dart';
+
 import 'content_descriptor.dart';
 import 'event.dart';
 
@@ -30,7 +32,7 @@ class Show {
   final DateTime start;
   final DateTime end;
   final EventImageData images;
-  final List<ContentDescriptor> contentDescriptors;
+  final KtList<ContentDescriptor> contentDescriptors;
 
   @override
   bool operator ==(Object other) =>

--- a/core/lib/src/networking/finnkino_api.dart
+++ b/core/lib/src/networking/finnkino_api.dart
@@ -8,6 +8,7 @@ import 'package:core/src/parsers/event_parser.dart';
 import 'package:core/src/parsers/show_parser.dart';
 import 'package:http/http.dart';
 import 'package:intl/intl.dart';
+import 'package:kt_dart/collection.dart';
 
 class FinnkinoApi {
   static final ddMMyyyy = DateFormat('dd.MM.yyyy');
@@ -17,15 +18,18 @@ class FinnkinoApi {
   static bool useFinnish = false;
 
   FinnkinoApi(this.client);
+
   final Client client;
 
   String get localizedPath => useFinnish ? '' : '/en';
+
   Uri get kScheduleBaseUrl =>
       Uri.https('www.finnkino.fi', '$localizedPath/xml/Schedule');
+
   Uri get kEventsBaseUrl =>
       Uri.https('www.finnkino.fi', '$localizedPath/xml/Events');
 
-  Future<List<Show>> getSchedule(Theater theater, DateTime date) async {
+  Future<KtList<Show>> getSchedule(Theater theater, DateTime date) async {
     final dt = ddMMyyyy.format(date ?? new DateTime.now());
     final response = await client.get(
       kScheduleBaseUrl.replace(queryParameters: {
@@ -38,7 +42,7 @@ class FinnkinoApi {
     return ShowParser.parse(utf8.decode(response.bodyBytes));
   }
 
-  Future<List<Event>> getNowInTheatersEvents(Theater theater) async {
+  Future<KtList<Event>> getNowInTheatersEvents(Theater theater) async {
     final response = await client.get(
       kEventsBaseUrl.replace(queryParameters: {
         'area': theater.id,
@@ -50,7 +54,7 @@ class FinnkinoApi {
     return EventParser.parse(utf8.decode(response.bodyBytes));
   }
 
-  Future<List<Event>> getUpcomingEvents() async {
+  Future<KtList<Event>> getUpcomingEvents() async {
     final response = await client.get(
       kEventsBaseUrl.replace(queryParameters: {
         'listType': 'ComingSoon',

--- a/core/lib/src/networking/tmdb_api.dart
+++ b/core/lib/src/networking/tmdb_api.dart
@@ -5,6 +5,7 @@ import 'package:core/src/models/actor.dart';
 import 'package:core/src/models/event.dart';
 import 'package:core/src/tmdb_config.dart';
 import 'package:http/http.dart';
+import 'package:kt_dart/collection.dart';
 
 /// If this has a red underline, it means that the lib/tmdb_config.dart file
 /// is not present on the project. Refer to the README for instructions
@@ -16,8 +17,8 @@ class TMDBApi {
 
   static final String baseUrl = 'api.themoviedb.org';
 
-  Future<List<Actor>> findAvatarsForActors(
-      Event event, List<Actor> actors) async {
+  Future<KtList<Actor>> findAvatarsForActors(
+      Event event, KtList<Actor> actors) async {
     int movieId = await _findMovieId(event.originalTitle);
 
     if (movieId != null) {
@@ -46,7 +47,7 @@ class TMDBApi {
     return null;
   }
 
-  Future<List<Actor>> _getActorAvatars(int movieId) async {
+  Future<KtList<Actor>> _getActorAvatars(int movieId) async {
     final actorUri = Uri.https(
       baseUrl,
       '3/movie/$movieId/credits',
@@ -61,8 +62,8 @@ class TMDBApi {
         (movieActors['cast'] as List).cast<Map<String, dynamic>>());
   }
 
-  List<Actor> _parseActorAvatars(List<Map<String, dynamic>> movieCast) {
-    final actorsWithAvatars = <Actor>[];
+  KtList<Actor> _parseActorAvatars(List<Map<String, dynamic>> movieCast) {
+    final actorsWithAvatars = mutableListOf<Actor>();
 
     movieCast.forEach((Map<String, dynamic> castMember) {
       String pp = castMember['profile_path'];

--- a/core/lib/src/parsers/content_descriptor_parser.dart
+++ b/core/lib/src/parsers/content_descriptor_parser.dart
@@ -1,19 +1,22 @@
 import 'package:core/src/models/content_descriptor.dart';
 import 'package:core/src/networking/image_url_rewriter.dart';
 import 'package:core/src/utils/xml_utils.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:xml/xml.dart';
 
 class ContentDescriptorParser {
-  static List<ContentDescriptor> parse(Iterable<XmlElement> roots) {
+  static KtList<ContentDescriptor> parse(Iterable<XmlElement> roots) {
     if (roots == null) {
-      return [];
+      return emptyList();
     }
 
-    return roots.first.findElements('ContentDescriptor').map((element) {
+    var contentDescriptors =
+        listFrom(roots).first().findElements('ContentDescriptor');
+    return listFrom(contentDescriptors).map((element) {
       return ContentDescriptor(
         name: tagContentsOrNull(element, 'Name'),
         imageUrl: rewriteImageUrl(tagContentsOrNull(element, 'ImageURL')),
       );
-    }).toList();
+    });
   }
 }

--- a/core/lib/src/parsers/event_parser.dart
+++ b/core/lib/src/parsers/event_parser.dart
@@ -1,18 +1,19 @@
 import 'package:core/src/models/actor.dart';
 import 'package:core/src/models/event.dart';
+import 'package:core/src/networking/image_url_rewriter.dart';
 import 'package:core/src/parsers/content_descriptor_parser.dart';
 import 'package:core/src/parsers/gallery_parser.dart';
-import 'package:core/src/networking/image_url_rewriter.dart';
 import 'package:core/src/utils/event_name_cleaner.dart';
 import 'package:core/src/utils/xml_utils.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:xml/xml.dart' as xml;
 
 class EventParser {
-  static List<Event> parse(String xmlString) {
+  static KtList<Event> parse(String xmlString) {
     final document = xml.parse(xmlString);
     final events = document.findAllElements('Event');
 
-    return events.map((node) {
+    return listFrom(events).map((node) {
       final title = tagContents(node, 'Title');
       final originalTitle = tagContents(node, 'OriginalTitle');
 
@@ -37,7 +38,7 @@ class EventParser {
         youtubeTrailers: _parseTrailers(node.findAllElements('EventVideo')),
         galleryImages: GalleryParser.parse(node.findElements('Gallery')),
       );
-    }).toList();
+    });
   }
 
   static DateTime _parseReleaseDate(String rawDate) {
@@ -48,28 +49,28 @@ class EventParser {
     }
   }
 
-  static List<String> _parseDirectors(Iterable<xml.XmlElement> nodes) {
-    return nodes.map((node) {
+  static KtList<String> _parseDirectors(Iterable<xml.XmlElement> nodes) {
+    return listFrom(nodes).map((node) {
       final first = tagContents(node, 'FirstName');
       final last = tagContents(node, 'LastName');
 
       return '$first $last';
-    }).toList();
+    });
   }
 
-  static List<Actor> _parseActors(Iterable<xml.XmlElement> nodes) {
-    return nodes.map((node) {
+  static KtList<Actor> _parseActors(Iterable<xml.XmlElement> nodes) {
+    return listFrom(nodes).map((node) {
       final first = tagContents(node, 'FirstName');
       final last = tagContents(node, 'LastName');
 
       return Actor(name: '$first $last');
-    }).toList();
+    });
   }
 
-  static List<String> _parseTrailers(Iterable<xml.XmlElement> nodes) {
-    return nodes.map((node) {
+  static KtList<String> _parseTrailers(Iterable<xml.XmlElement> nodes) {
+    return listFrom(nodes).map((node) {
       return 'https://youtube.com/watch?v=' + tagContents(node, 'Location');
-    }).toList();
+    });
   }
 }
 
@@ -97,7 +98,6 @@ class EventImageDataParser {
       landscapeHd2: _getHdImageUrl2(landscapeBig),
     );
   }
-
 
   ///
   /// This hacky hack only exists because Finnkino API doesn't return HD

--- a/core/lib/src/parsers/gallery_parser.dart
+++ b/core/lib/src/parsers/gallery_parser.dart
@@ -1,20 +1,22 @@
 import 'package:core/src/models/event.dart';
 import 'package:core/src/networking/image_url_rewriter.dart';
 import 'package:core/src/utils/xml_utils.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:xml/xml.dart';
 
 class GalleryParser {
-  static List<GalleryImage> parse(Iterable<XmlElement> roots) {
+  static KtList<GalleryImage> parse(Iterable<XmlElement> roots) {
     if (roots == null || roots.isEmpty) {
-      return [];
+      return emptyList();
     }
 
-    return roots.first.findElements('GalleryImage').map((node) {
+    var galleryImage = listFrom(roots).first().findElements('GalleryImage');
+    return listFrom(galleryImage).map((node) {
       return GalleryImage(
         thumbnailLocation:
             rewriteImageUrl(tagContents(node, 'ThumbnailLocation')),
         location: rewriteImageUrl(tagContents(node, 'Location')),
       );
-    }).toList();
+    });
   }
 }

--- a/core/lib/src/parsers/show_parser.dart
+++ b/core/lib/src/parsers/show_parser.dart
@@ -1,17 +1,18 @@
 import 'package:core/src/models/show.dart';
+import 'package:core/src/networking/image_url_rewriter.dart';
 import 'package:core/src/parsers/content_descriptor_parser.dart';
 import 'package:core/src/parsers/event_parser.dart';
-import 'package:core/src/networking/image_url_rewriter.dart';
 import 'package:core/src/utils/event_name_cleaner.dart';
 import 'package:core/src/utils/xml_utils.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:xml/xml.dart' as xml;
 
 class ShowParser {
-  static List<Show> parse(String xmlString) {
+  static KtList<Show> parse(String xmlString) {
     final document = xml.parse(xmlString);
     final shows = document.findAllElements('Show');
 
-    return shows.map((node) {
+    return listFrom(shows).map((node) {
       final title = tagContents(node, 'Title');
       final originalTitle = tagContents(node, 'OriginalTitle');
 
@@ -32,6 +33,6 @@ class ShowParser {
         contentDescriptors: ContentDescriptorParser.parse(
             node.findElements('ContentDescriptors')),
       );
-    }).toList();
+    });
   }
 }

--- a/core/lib/src/parsers/theater_parser.dart
+++ b/core/lib/src/parsers/theater_parser.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/theater.dart';
 import 'package:core/src/utils/xml_utils.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:xml/xml.dart' as xml;
 
 final RegExp _nameExpr = new RegExp(r'([A-Z])([A-Z]+)');
@@ -10,11 +11,9 @@ class TheaterParser {
   /// theater". Thanks Finnkino.
   static const String kChooseTheaterId = '1029';
 
-  static List<Theater> parse(String xmlString) {
+  static KtList<Theater> parse(String xmlString) {
     final document = xml.parse(xmlString);
-    final theaters = document.findAllElements('TheatreArea');
-
-    return theaters.map((node) {
+    final theaters = document.findAllElements('TheatreArea').map((node) {
       final id = tagContents(node, 'ID');
       var normalizedName = _normalize(tagContents(node, 'Name'));
 
@@ -26,7 +25,9 @@ class TheaterParser {
         id: id,
         name: normalizedName,
       );
-    }).toList();
+    });
+
+    return listFrom(theaters);
   }
 
   static String _normalize(String text) {

--- a/core/lib/src/redux/_common/common_actions.dart
+++ b/core/lib/src/redux/_common/common_actions.dart
@@ -1,6 +1,7 @@
 import 'package:core/src/models/actor.dart';
 import 'package:core/src/models/event.dart';
 import 'package:core/src/models/theater.dart';
+import 'package:kt_dart/collection.dart';
 
 class InitAction {}
 
@@ -25,5 +26,5 @@ class UpdateActorsForEventAction {
   UpdateActorsForEventAction(this.event, this.actors);
 
   final Event event;
-  final List<Actor> actors;
+  final KtList<Actor> actors;
 }

--- a/core/lib/src/redux/_common/common_actions.dart
+++ b/core/lib/src/redux/_common/common_actions.dart
@@ -11,7 +11,7 @@ class InitCompleteAction {
     this.selectedTheater,
   );
 
-  final List<Theater> theaters;
+  final KtList<Theater> theaters;
   final Theater selectedTheater;
 }
 

--- a/core/lib/src/redux/actor/actor_actions.dart
+++ b/core/lib/src/redux/actor/actor_actions.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/actor.dart';
 import 'package:core/src/models/event.dart';
+import 'package:kt_dart/collection.dart';
 
 class FetchActorAvatarsAction {
   FetchActorAvatarsAction(this.event);
@@ -8,10 +9,10 @@ class FetchActorAvatarsAction {
 
 class ActorsUpdatedAction {
   ActorsUpdatedAction(this.actors);
-  final List<Actor> actors;
+  final KtList<Actor> actors;
 }
 
 class ReceivedActorAvatarsAction {
   ReceivedActorAvatarsAction(this.actors);
-  final List<Actor> actors;
+  final KtList<Actor> actors;
 }

--- a/core/lib/src/redux/actor/actor_reducer.dart
+++ b/core/lib/src/redux/actor/actor_reducer.dart
@@ -1,7 +1,8 @@
 import 'package:core/src/models/actor.dart';
 import 'package:core/src/redux/actor/actor_actions.dart';
+import 'package:kt_dart/collection.dart';
 
-Map<String, Actor> actorReducer(Map<String, Actor> state, dynamic action) {
+KtMap<String, Actor> actorReducer(KtMap<String, Actor> state, dynamic action) {
   if (action is ActorsUpdatedAction) {
     return _updateActors(state, action);
   } else if (action is ReceivedActorAvatarsAction) {
@@ -11,24 +12,24 @@ Map<String, Actor> actorReducer(Map<String, Actor> state, dynamic action) {
   return state;
 }
 
-Map<String, Actor> _updateActors(Map<String, Actor> state, dynamic action) {
-  final actors = <String, Actor>{}..addAll(state);
-  action.actors.forEach((Actor actor) {
-    actors.putIfAbsent(actor.name, () => Actor(name: actor.name));
+KtMap<String, Actor> _updateActors(
+    KtMap<String, Actor> state, ActorsUpdatedAction action) {
+  final actors = state.toMutableMap();
+  action.actors.forEach((actor) {
+    actors.putIfAbsent(actor.name, Actor(name: actor.name));
   });
-
-  return actors;
+  return actors.toMap();
 }
 
-Map<String, Actor> _updateActorAvatars(
-    Map<String, Actor> state, dynamic action) {
-  final actorsWithAvatars = <String, Actor>{}..addAll(state);
-  action.actors.forEach((Actor actor) {
+KtMap<String, Actor> _updateActorAvatars(
+    KtMap<String, Actor> state, ReceivedActorAvatarsAction action) {
+  final actorsWithAvatars = state.toMutableMap();
+  action.actors.forEach((actor) {
     actorsWithAvatars[actor.name] = Actor(
       name: actor.name,
       avatarUrl: actor.avatarUrl,
     );
   });
 
-  return actorsWithAvatars;
+  return actorsWithAvatars.toMap();
 }

--- a/core/lib/src/redux/actor/actor_selectors.dart
+++ b/core/lib/src/redux/actor/actor_selectors.dart
@@ -1,9 +1,9 @@
 import 'package:core/src/models/actor.dart';
 import 'package:core/src/models/event.dart';
 import 'package:core/src/redux/app/app_state.dart';
+import 'package:kt_dart/collection.dart';
 
-List<Actor> actorsForEventSelector(AppState state, Event event) {
+KtList<Actor> actorsForEventSelector(AppState state, Event event) {
   return state.actorsByName.values
-      .where((actor) => event.actors.contains(actor))
-      .toList();
+      .filter((actor) => event.actors.contains(actor));
 }

--- a/core/lib/src/redux/app/app_state.dart
+++ b/core/lib/src/redux/app/app_state.dart
@@ -2,6 +2,7 @@ import 'package:core/src/models/actor.dart';
 import 'package:core/src/redux/event/event_state.dart';
 import 'package:core/src/redux/show/show_state.dart';
 import 'package:core/src/redux/theater/theater_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 @immutable
@@ -15,7 +16,7 @@ class AppState {
   });
 
   final String searchQuery;
-  final Map<String, Actor> actorsByName;
+  final KtMap<String, Actor> actorsByName;
   final TheaterState theaterState;
   final ShowState showState;
   final EventState eventState;
@@ -23,7 +24,7 @@ class AppState {
   factory AppState.initial() {
     return AppState(
       searchQuery: null,
-      actorsByName: <String, Actor>{},
+      actorsByName: emptyMap(),
       theaterState: TheaterState.initial(),
       showState: ShowState.initial(),
       eventState: EventState.initial(),
@@ -32,7 +33,7 @@ class AppState {
 
   AppState copyWith({
     String searchQuery,
-    Map<String, Actor> actorsByName,
+    KtMap<String, Actor> actorsByName,
     TheaterState theaterState,
     ShowState showState,
     EventState eventState,

--- a/core/lib/src/redux/event/event_actions.dart
+++ b/core/lib/src/redux/event/event_actions.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/event.dart';
 import 'package:core/src/models/theater.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 class RefreshEventsAction {
@@ -14,12 +15,12 @@ class RequestingEventsAction {
 
 class ReceivedInTheatersEventsAction {
   ReceivedInTheatersEventsAction(this.events);
-  final List<Event> events;
+  final KtList<Event> events;
 }
 
 class ReceivedComingSoonEventsAction {
   ReceivedComingSoonEventsAction(this.events);
-  final List<Event> events;
+  final KtList<Event> events;
 }
 
 class ErrorLoadingEventsAction {

--- a/core/lib/src/redux/event/event_reducer.dart
+++ b/core/lib/src/redux/event/event_reducer.dart
@@ -3,6 +3,7 @@ import 'package:core/src/models/loading_status.dart';
 import 'package:core/src/redux/_common/common_actions.dart';
 import 'package:core/src/redux/event/event_actions.dart';
 import 'package:core/src/redux/event/event_state.dart';
+import 'package:kt_dart/collection.dart';
 
 EventState eventReducer(EventState state, dynamic action) {
   if (action is RequestingEventsAction) {
@@ -58,16 +59,16 @@ EventState _updateActorsForEvent(
   );
 }
 
-List<Event> _addActorImagesToEvent(
-    List<Event> originalEvents, Event replacement) {
-  final newEvents = <Event>[]..addAll(originalEvents);
-  final positionToReplace = originalEvents.indexWhere((candidate) {
-    return candidate.id == replacement.id;
-  });
+KtList<Event> _addActorImagesToEvent(
+    KtList<Event> originalEvents, Event replacement) {
+  final positionToReplace = originalEvents
+      .indexOfFirst((candidate) => candidate.id == replacement.id);
 
   if (positionToReplace > -1) {
+    final newEvents = originalEvents.toMutableList();
     newEvents[positionToReplace] = replacement;
+    return newEvents;
   }
 
-  return newEvents;
+  return originalEvents;
 }

--- a/core/lib/src/redux/event/event_selectors.dart
+++ b/core/lib/src/redux/event/event_selectors.dart
@@ -39,7 +39,12 @@ KtList<Event> _eventsOrEventSearch(KtList<Event> events, String searchQuery) {
 /// do this hack because it is quite boring to display four movie posters that
 /// are exactly the same.
 KtList<Event> _uniqueEvents(KtList<Event> original) {
-  return original.associateBy((event) => event.originalTitle).values;
+  return original
+      // reverse because last unique key wins
+      .reversed()
+      .associateBy((event) => event.originalTitle)
+      .values
+      .reversed();
 }
 
 KtList<Event> _eventsWithSearchQuery(

--- a/core/lib/src/redux/event/event_selectors.dart
+++ b/core/lib/src/redux/event/event_selectors.dart
@@ -1,8 +1,7 @@
-import 'dart:collection';
-
 import 'package:core/src/models/event.dart';
 import 'package:core/src/models/show.dart';
 import 'package:core/src/redux/app/app_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:reselect/reselect.dart';
 
 final nowInTheatersSelector = createSelector2(
@@ -19,25 +18,17 @@ final comingSoonSelector = createSelector2(
 
 Event eventByIdSelector(AppState state, String id) {
   final predicate = (event) => event.id == id;
-
-  return nowInTheatersSelector(state).firstWhere(
-    predicate,
-    orElse: () {
-      return comingSoonSelector(state).firstWhere(
-        predicate,
-        orElse: () => null,
-      );
-    },
-  );
+  return nowInTheatersSelector(state).firstOrNull(predicate) ??
+      comingSoonSelector(state).firstOrNull(predicate);
 }
 
 Event eventForShowSelector(AppState state, Show show) {
   return state.eventState.nowInTheatersEvents
-      .where((event) => event.id == show.eventId)
-      .first;
+      .filter((event) => event.id == show.eventId)
+      .first();
 }
 
-List<Event> _eventsOrEventSearch(List<Event> events, String searchQuery) {
+KtList<Event> _eventsOrEventSearch(KtList<Event> events, String searchQuery) {
   return searchQuery == null
       ? _uniqueEvents(events)
       : _eventsWithSearchQuery(events, searchQuery);
@@ -47,20 +38,16 @@ List<Event> _eventsOrEventSearch(List<Event> events, String searchQuery) {
 /// completely different events, we might get a lot of duplication. We have to
 /// do this hack because it is quite boring to display four movie posters that
 /// are exactly the same.
-List<Event> _uniqueEvents(List<Event> original) {
-  final uniqueEventMap = LinkedHashMap<String, Event>();
-  original.forEach((event) {
-    uniqueEventMap[event.originalTitle] = event;
-  });
-
-  return uniqueEventMap.values.toList();
+KtList<Event> _uniqueEvents(KtList<Event> original) {
+  return original.associateBy((event) => event.originalTitle).values;
 }
 
-List<Event> _eventsWithSearchQuery(List<Event> original, String searchQuery) {
+KtList<Event> _eventsWithSearchQuery(
+    KtList<Event> original, String searchQuery) {
   final searchQueryPattern = RegExp(searchQuery, caseSensitive: false);
 
-  return original.where((event) {
+  return original.filter((event) {
     return event.title.contains(searchQueryPattern) ||
         event.originalTitle.contains(searchQueryPattern);
-  }).toList();
+  });
 }

--- a/core/lib/src/redux/event/event_state.dart
+++ b/core/lib/src/redux/event/event_state.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/event.dart';
 import 'package:core/src/models/loading_status.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 @immutable
@@ -12,24 +13,24 @@ class EventState {
   });
 
   final LoadingStatus nowInTheatersStatus;
-  final List<Event> nowInTheatersEvents;
+  final KtList<Event> nowInTheatersEvents;
   final LoadingStatus comingSoonStatus;
-  final List<Event> comingSoonEvents;
+  final KtList<Event> comingSoonEvents;
 
   factory EventState.initial() {
     return EventState(
       nowInTheatersStatus: LoadingStatus.idle,
-      nowInTheatersEvents: [],
+      nowInTheatersEvents: emptyList(),
       comingSoonStatus: LoadingStatus.idle,
-      comingSoonEvents: [],
+      comingSoonEvents: emptyList(),
     );
   }
 
   EventState copyWith({
     LoadingStatus nowInTheatersStatus,
-    List<Event> nowInTheatersEvents,
+    KtList<Event> nowInTheatersEvents,
     LoadingStatus comingSoonStatus,
-    List<Event> comingSoonEvents,
+    KtList<Event> comingSoonEvents,
   }) {
     return EventState(
       nowInTheatersStatus: nowInTheatersStatus ?? this.nowInTheatersStatus,

--- a/core/lib/src/redux/show/show_actions.dart
+++ b/core/lib/src/redux/show/show_actions.dart
@@ -1,24 +1,29 @@
 import 'package:core/src/models/show.dart';
 import 'package:core/src/models/show_cache.dart';
 import 'package:core/src/models/theater.dart';
+import 'package:kt_dart/collection.dart';
 
 class UpdateShowDatesAction {}
+
 class ShowDatesUpdatedAction {
   ShowDatesUpdatedAction(this.dates);
-  final List<DateTime> dates;
+  final KtList<DateTime> dates;
 }
 
 class FetchShowsIfNotLoadedAction {}
 
 class RequestingShowsAction {}
+
 class RefreshShowsAction {}
+
 class ReceivedShowsAction {
   ReceivedShowsAction(this.cacheKey, this.shows);
   final DateTheaterPair cacheKey;
-  final List<Show> shows;
+  final KtList<Show> shows;
 }
 
 class ErrorLoadingShowsAction {}
+
 class ChangeCurrentDateAction {
   ChangeCurrentDateAction(this.date);
   final DateTime date;

--- a/core/lib/src/redux/show/show_middleware.dart
+++ b/core/lib/src/redux/show/show_middleware.dart
@@ -9,10 +9,12 @@ import 'package:core/src/redux/_common/common_actions.dart';
 import 'package:core/src/redux/app/app_state.dart';
 import 'package:core/src/redux/show/show_actions.dart';
 import 'package:core/src/utils/clock.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:redux/redux.dart';
 
 class ShowMiddleware extends MiddlewareClass<AppState> {
   ShowMiddleware(this.api);
+
   final FinnkinoApi api;
 
   @override
@@ -39,7 +41,8 @@ class ShowMiddleware extends MiddlewareClass<AppState> {
 
   void _updateShowDates(dynamic action, NextDispatcher next) {
     final now = Clock.getCurrentTime();
-    var dates = List.generate(7, (index) => now.add(Duration(days: index)));
+    var dates =
+        listFrom(List.generate(7, (index) => now.add(Duration(days: index))));
 
     next(new ShowDatesUpdatedAction(dates));
   }
@@ -65,13 +68,13 @@ class ShowMiddleware extends MiddlewareClass<AppState> {
     }
   }
 
-  Future<List<Show>> _fetchShows(
+  Future<KtList<Show>> _fetchShows(
       DateTime currentDate, Theater newTheater, NextDispatcher next) async {
     final shows = await api.getSchedule(newTheater, currentDate);
     final now = Clock.getCurrentTime();
 
     // Return only show times that haven't started yet.
-    return shows.where((show) => show.start.isAfter(now)).toList();
+    return shows.filter((show) => show.start.isAfter(now));
   }
 
   Theater _getCorrectTheater(Store<AppState> store, dynamic action) {

--- a/core/lib/src/redux/show/show_reducer.dart
+++ b/core/lib/src/redux/show/show_reducer.dart
@@ -1,19 +1,17 @@
 import 'package:core/src/models/loading_status.dart';
-import 'package:core/src/models/show.dart';
-import 'package:core/src/models/show_cache.dart';
 import 'package:core/src/redux/_common/common_actions.dart';
 import 'package:core/src/redux/show/show_actions.dart';
 import 'package:core/src/redux/show/show_state.dart';
 
 ShowState showReducer(ShowState state, dynamic action) {
   if (action is ChangeCurrentTheaterAction) {
-    return state.copyWith(selectedDate: state.dates.first);
+    return state.copyWith(selectedDate: state.dates.first());
   } else if (action is ChangeCurrentDateAction) {
     return state.copyWith(selectedDate: action.date);
   } else if (action is RequestingShowsAction) {
     return state.copyWith(loadingStatus: LoadingStatus.loading);
   } else if (action is ReceivedShowsAction) {
-    final newShows = <DateTheaterPair, List<Show>>{}..addAll(state.shows);
+    final newShows = state.shows.toMutableMap();
     newShows[action.cacheKey] = action.shows;
 
     return state.copyWith(
@@ -25,7 +23,7 @@ ShowState showReducer(ShowState state, dynamic action) {
   } else if (action is ShowDatesUpdatedAction) {
     return state.copyWith(
       availableDates: action.dates,
-      selectedDate: action.dates.first,
+      selectedDate: action.dates.first(),
     );
   }
 

--- a/core/lib/src/redux/show/show_selectors.dart
+++ b/core/lib/src/redux/show/show_selectors.dart
@@ -32,10 +32,8 @@ final showsSelector = createSelector3<AppState, DateTheaterPair,
 );
 
 final showsForEventSelector =
-    memo2<List<Show>, Event, List<Show>>((shows, event) {
-  return shows
-      .where((show) => show.originalTitle == event.originalTitle)
-      .toList();
+    memo2<KtList<Show>, Event, KtList<Show>>((shows, event) {
+  return shows.filter((show) => show.originalTitle == event.originalTitle);
 });
 
 KtList<Show> _showsWithSearchQuery(KtList<Show> shows, String searchQuery) {

--- a/core/lib/src/redux/show/show_selectors.dart
+++ b/core/lib/src/redux/show/show_selectors.dart
@@ -2,14 +2,13 @@ import 'package:core/src/models/event.dart';
 import 'package:core/src/models/show.dart';
 import 'package:core/src/models/show_cache.dart';
 import 'package:core/src/redux/app/app_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:memoize/memoize.dart';
 import 'package:reselect/reselect.dart';
 
 Show showByIdSelector(AppState state, String id) {
-  return showsSelector(state).firstWhere(
-    (show) => show.id == id,
-    orElse: () => _findFromAllShows(state, id),
-  );
+  return showsSelector(state).firstOrNull((show) => show.id == id) ??
+      _findFromAllShows(state, id);
 }
 
 /// Selects a list of shows based on the currently selected date and theater.
@@ -18,16 +17,17 @@ Show showByIdSelector(AppState state, String id) {
 /// that search query. Otherwise returns all matching shows for current theater
 /// and date.
 final showsSelector = createSelector3<AppState, DateTheaterPair,
-    Map<DateTheaterPair, List<Show>>, String, List<Show>>(
+    KtMap<DateTheaterPair, KtList<Show>>, String, KtList<Show>>(
   (state) => DateTheaterPair.fromState(state),
   (state) => state.showState.shows,
   (state) => state.searchQuery,
-  (key, shows, searchQuery) {
-    final matchingShows = shows[key] ?? [];
-
-    return searchQuery == null
-        ? matchingShows
-        : _showsWithSearchQuery(matchingShows, searchQuery);
+  (key, KtMap<DateTheaterPair, KtList<Show>> shows, searchQuery) {
+    KtList<Show> matchingShows = shows.getOrDefault(key, emptyList<Show>());
+    if (searchQuery == null) {
+      return matchingShows;
+    } else {
+      return _showsWithSearchQuery(matchingShows, searchQuery);
+    }
   },
 );
 
@@ -38,13 +38,12 @@ final showsForEventSelector =
       .toList();
 });
 
-List<Show> _showsWithSearchQuery(List<Show> shows, String searchQuery) {
+KtList<Show> _showsWithSearchQuery(KtList<Show> shows, String searchQuery) {
   final searchQueryPattern = new RegExp(searchQuery, caseSensitive: false);
 
-  return shows.where((show) {
-    return show.title.contains(searchQueryPattern) ||
-        show.originalTitle.contains(searchQueryPattern);
-  }).toList();
+  return shows.filter((show) =>
+      show.title.contains(searchQueryPattern) ||
+      show.originalTitle.contains(searchQueryPattern));
 }
 
 /// Goes through the list of showtimes for every single theater.
@@ -54,15 +53,8 @@ List<Show> _showsWithSearchQuery(List<Show> shows, String searchQuery) {
 /// when [showByIdSelector] fails.
 Show _findFromAllShows(AppState state, String id) {
   final allShows = state.showState.shows.values;
-  return allShows.firstWhere(
-    (shows) {
-      final match = shows.firstWhere(
-        (show) => show.id == id,
-        orElse: () => null,
-      );
-
-      return match != null;
-    },
-    orElse: () => null,
-  )?.first;
+  return allShows
+      .firstOrNull(
+          (shows) => shows.firstOrNull((show) => show.id == id) != null)
+      ?.firstOrNull();
 }

--- a/core/lib/src/redux/show/show_state.dart
+++ b/core/lib/src/redux/show/show_state.dart
@@ -1,6 +1,7 @@
 import 'package:core/src/models/loading_status.dart';
 import 'package:core/src/models/show.dart';
 import 'package:core/src/models/show_cache.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 @immutable
@@ -13,24 +14,24 @@ class ShowState {
   });
 
   final LoadingStatus loadingStatus;
-  final List<DateTime> dates;
+  final KtList<DateTime> dates;
   final DateTime selectedDate;
-  final Map<DateTheaterPair, List<Show>> shows;
+  final KtMap<DateTheaterPair, KtList<Show>> shows;
 
   factory ShowState.initial() {
     return ShowState(
       loadingStatus: LoadingStatus.idle,
-      dates: [],
+      dates: emptyList(),
       selectedDate: null,
-      shows: {},
+      shows: emptyMap(),
     );
   }
 
   ShowState copyWith({
     LoadingStatus loadingStatus,
-    List<DateTime> availableDates,
+    KtList<DateTime> availableDates,
     DateTime selectedDate,
-    Map<DateTheaterPair, List<Show>> shows,
+    KtMap<DateTheaterPair, KtList<Show>> shows,
   }) {
     return ShowState(
       loadingStatus: loadingStatus ?? this.loadingStatus,

--- a/core/lib/src/redux/theater/theater_middleware.dart
+++ b/core/lib/src/redux/theater/theater_middleware.dart
@@ -6,12 +6,14 @@ import 'package:core/src/preloaded_data.dart';
 import 'package:core/src/redux/_common/common_actions.dart';
 import 'package:core/src/redux/app/app_state.dart';
 import 'package:key_value_store/key_value_store.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:redux/redux.dart';
 
 class TheaterMiddleware extends MiddlewareClass<AppState> {
   static const String kDefaultTheaterId = 'default_theater_id';
 
   TheaterMiddleware(this.keyValueStore);
+
   final KeyValueStore keyValueStore;
 
   @override
@@ -40,20 +42,18 @@ class TheaterMiddleware extends MiddlewareClass<AppState> {
     next(action);
   }
 
-  Theater _getDefaultTheater(List<Theater> allTheaters) {
+  Theater _getDefaultTheater(KtList<Theater> allTheaters) {
     var persistedTheaterId = keyValueStore.getString(kDefaultTheaterId);
 
     if (persistedTheaterId != null) {
-      return allTheaters.singleWhere((theater) {
+      return allTheaters.single((theater) {
         return theater.id == persistedTheaterId;
       });
     }
 
-    return allTheaters.singleWhere(
-      /// Default to Helsinki -> no reason to load movie information for the
-      /// whole country at first.
-      (theater) => theater.id == '1033',
-      orElse: () => allTheaters.first,
-    );
+    /// Default to Helsinki -> no reason to load movie information for the
+    /// whole country at first.
+    return allTheaters.singleOrNull((theater) => theater.id == '1033') ??
+        allTheaters.first;
   }
 }

--- a/core/lib/src/redux/theater/theater_selectors.dart
+++ b/core/lib/src/redux/theater/theater_selectors.dart
@@ -1,7 +1,8 @@
 import 'package:core/src/models/theater.dart';
 import 'package:core/src/redux/app/app_state.dart';
+import 'package:kt_dart/collection.dart';
 
 Theater currentTheaterSelector(AppState state) =>
     state.theaterState.currentTheater;
 
-List<Theater> theatersSelector(AppState state) => state.theaterState.theaters;
+KtList<Theater> theatersSelector(AppState state) => state.theaterState.theaters;

--- a/core/lib/src/redux/theater/theater_state.dart
+++ b/core/lib/src/redux/theater/theater_state.dart
@@ -1,4 +1,5 @@
 import 'package:core/src/models/theater.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 @immutable
@@ -9,18 +10,18 @@ class TheaterState {
   });
 
   final Theater currentTheater;
-  final List<Theater> theaters;
+  final KtList<Theater> theaters;
 
   factory TheaterState.initial() {
     return TheaterState(
       currentTheater: null,
-      theaters: [],
+      theaters: emptyList(),
     );
   }
 
   TheaterState copyWith({
     Theater currentTheater,
-    List<Theater> theaters,
+    KtList<Theater> theaters,
   }) {
     return TheaterState(
       currentTheater: currentTheater ?? this.currentTheater,

--- a/core/lib/src/viewmodels/events_page_view_model.dart
+++ b/core/lib/src/viewmodels/events_page_view_model.dart
@@ -1,9 +1,9 @@
-import 'package:collection/collection.dart';
 import 'package:core/src/models/event.dart';
 import 'package:core/src/models/loading_status.dart';
 import 'package:core/src/redux/app/app_state.dart';
 import 'package:core/src/redux/event/event_actions.dart';
 import 'package:core/src/redux/event/event_selectors.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:redux/redux.dart';
 
@@ -15,7 +15,7 @@ class EventsPageViewModel {
   });
 
   final LoadingStatus status;
-  final List<Event> events;
+  final KtList<Event> events;
   final Function refreshEvents;
 
   static EventsPageViewModel fromStore(
@@ -39,8 +39,8 @@ class EventsPageViewModel {
       other is EventsPageViewModel &&
           runtimeType == other.runtimeType &&
           status == other.status &&
-          const IterableEquality().equals(events, other.events);
+          events == other.events;
 
   @override
-  int get hashCode => status.hashCode ^ const IterableEquality().hash(events);
+  int get hashCode => status.hashCode ^ events.hashCode;
 }

--- a/core/lib/src/viewmodels/showtime_page_view_model.dart
+++ b/core/lib/src/viewmodels/showtime_page_view_model.dart
@@ -1,9 +1,9 @@
-import 'package:collection/collection.dart';
 import 'package:core/src/models/loading_status.dart';
 import 'package:core/src/models/show.dart';
 import 'package:core/src/redux/app/app_state.dart';
 import 'package:core/src/redux/show/show_actions.dart';
 import 'package:core/src/redux/show/show_selectors.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:redux/redux.dart';
 
@@ -18,9 +18,9 @@ class ShowtimesPageViewModel {
   });
 
   final LoadingStatus status;
-  final List<DateTime> dates;
+  final KtList<DateTime> dates;
   final DateTime selectedDate;
-  final List<Show> shows;
+  final KtList<Show> shows;
   final Function(DateTime) changeCurrentDate;
   final Function refreshShowtimes;
 
@@ -43,14 +43,11 @@ class ShowtimesPageViewModel {
       other is ShowtimesPageViewModel &&
           runtimeType == other.runtimeType &&
           status == other.status &&
-          const IterableEquality().equals(dates, other.dates) &&
+          dates == other.dates &&
           selectedDate == other.selectedDate &&
-          const IterableEquality().equals(shows, other.shows);
+          shows == other.shows;
 
   @override
   int get hashCode =>
-      status.hashCode ^
-      const IterableEquality().hash(dates) ^
-      selectedDate.hashCode ^
-      const IterableEquality().hash(shows);
+      status.hashCode ^ dates.hashCode ^ selectedDate.hashCode ^ shows.hashCode;
 }

--- a/core/lib/src/viewmodels/theater_list_view_model.dart
+++ b/core/lib/src/viewmodels/theater_list_view_model.dart
@@ -1,8 +1,8 @@
-import 'package:collection/collection.dart';
 import 'package:core/src/models/theater.dart';
 import 'package:core/src/redux/_common/common_actions.dart';
 import 'package:core/src/redux/app/app_state.dart';
 import 'package:core/src/redux/theater/theater_selectors.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:redux/redux.dart';
 
@@ -14,7 +14,7 @@ class TheaterListViewModel {
   });
 
   final Theater currentTheater;
-  final List<Theater> theaters;
+  final KtList<Theater> theaters;
   final Function(Theater) changeCurrentTheater;
 
   static TheaterListViewModel fromStore(Store<AppState> store) {
@@ -33,9 +33,8 @@ class TheaterListViewModel {
       other is TheaterListViewModel &&
           runtimeType == other.runtimeType &&
           currentTheater == other.currentTheater &&
-          const IterableEquality().equals(theaters, other.theaters);
+          theaters == other.theaters;
 
   @override
-  int get hashCode =>
-      currentTheater.hashCode ^ const IterableEquality().hash(theaters);
+  int get hashCode => currentTheater.hashCode ^ theaters.hashCode;
 }

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   http: ^0.12.0
   reselect: ^0.4.0
   key_value_store: ^1.0.0
+  kt_dart: ^0.5.0
 
 dev_dependencies:
   test: ^1.3.0

--- a/core/test/parsers/event_parser_test.dart
+++ b/core/test/parsers/event_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/event.dart';
 import 'package:core/src/parsers/event_parser.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 import 'event_test_seeds.ignore.dart';
@@ -7,10 +8,10 @@ import 'event_test_seeds.ignore.dart';
 void main() {
   group('EventParser', () {
     test('parsing tests', () {
-      List<Event> deserialized = EventParser.parse(eventsXml);
-      expect(deserialized.length, 3);
+      KtList<Event> deserialized = EventParser.parse(eventsXml);
+      expect(deserialized.size, 3);
 
-      final paris1517 = deserialized.first;
+      final paris1517 = deserialized.first();
       expect(paris1517.id, '302535');
       expect(paris1517.title, '15:17 Pariisiin');
       expect(paris1517.originalTitle, 'The 15:17 to Paris');
@@ -19,15 +20,15 @@ void main() {
       expect(paris1517.ageRatingUrl,
           'https://inkino.imgix.net/images/rating_large_12.png?auto=format,compress');
       expect(paris1517.genres, 'Draama, Jännitys');
-      expect(paris1517.directors.length, 1);
-      expect(paris1517.directors.first, 'Clint Eastwood');
-      expect(paris1517.actors.length, 11);
-      expect(paris1517.actors.first.name, 'Anthony Sadler');
+      expect(paris1517.directors.size, 1);
+      expect(paris1517.directors.first(), 'Clint Eastwood');
+      expect(paris1517.actors.size, 11);
+      expect(paris1517.actors.first().name, 'Anthony Sadler');
       expect(paris1517.lengthInMinutes, '94');
       expect(paris1517.shortSynopsis, 'Short synopsis goes here.');
       expect(paris1517.synopsis, 'Synopsis goes here.');
-      expect(paris1517.youtubeTrailers.length, 1);
-      expect(paris1517.youtubeTrailers.first,
+      expect(paris1517.youtubeTrailers.size, 1);
+      expect(paris1517.youtubeTrailers.first(),
           'https://youtube.com/watch?v=oFa4C6OcuM4');
 
       final images = paris1517.images;
@@ -61,16 +62,16 @@ void main() {
       );
 
       final contentDescriptors = paris1517.contentDescriptors;
-      expect(contentDescriptors.length, 2);
+      expect(contentDescriptors.size, 2);
       expect(contentDescriptors[0].name, 'Violence');
       expect(contentDescriptors[0].imageUrl,
           'https://inkino.imgix.net/images/content_Violence.png?auto=format,compress');
 
       final gallery = paris1517.galleryImages;
-      expect(gallery.length, 8);
-      expect(gallery.first.thumbnailLocation,
+      expect(gallery.size, 8);
+      expect(gallery.first().thumbnailLocation,
           'https://inkino.imgix.net/1012/Event_12007/gallery/THUMB_Adrift_800a.jpg?auto=format,compress');
-      expect(gallery.first.location,
+      expect(gallery.first().location,
           'https://inkino.imgix.net/1012/Event_12007/gallery/Adrift_800a.jpg?auto=format,compress');
 
       expect(
@@ -78,7 +79,7 @@ void main() {
         'https://inkino.imgix.net/images/rating_large_Tulossa.png?auto=format,compress',
       );
 
-      expect(deserialized[1].actors, isEmpty);
+      expect(deserialized[1].actors, emptyList());
     });
   });
 }

--- a/core/test/parsers/show_parser_test.dart
+++ b/core/test/parsers/show_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/show.dart';
 import 'package:core/src/parsers/show_parser.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 import 'show_test_seeds.ignore.dart';
@@ -7,10 +8,10 @@ import 'show_test_seeds.ignore.dart';
 void main() {
   group('ShowParser', () {
     test('parsing test', () {
-      List<Show> deserialized = ShowParser.parse(showsXml);
-      expect(deserialized.length, 3);
+      KtList<Show> deserialized = ShowParser.parse(showsXml);
+      expect(deserialized.size, 3);
 
-      final jumanji = deserialized.first;
+      final jumanji = deserialized.first();
       expect(jumanji.id, '1155306');
       expect(jumanji.eventId, '302419');
       expect(jumanji.title, 'Jumanji: Welcome to the Jungle');
@@ -56,7 +57,7 @@ void main() {
       );
 
       final contentDescriptors = jumanji.contentDescriptors;
-      expect(contentDescriptors.length, 2);
+      expect(contentDescriptors.size, 2);
       expect(contentDescriptors[0].name, 'Violence');
       expect(contentDescriptors[0].imageUrl,
           'https://inkino.imgix.net/images/content_Violence.png?auto=format,compress');

--- a/core/test/parsers/theater_parser_test.dart
+++ b/core/test/parsers/theater_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/theater.dart';
 import 'package:core/src/parsers/theater_parser.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 import 'theater_test_seeds.ignore.dart';
@@ -7,8 +8,8 @@ import 'theater_test_seeds.ignore.dart';
 void main() {
   group('TheaterParser', () {
     test('parsing test', () {
-      List<Theater> deserialized = TheaterParser.parse(theatersXml);
-      expect(deserialized.length, 3);
+      KtList<Theater> deserialized = TheaterParser.parse(theatersXml);
+      expect(deserialized.size, 3);
 
       expect(deserialized[0].id, '1029');
       expect(deserialized[0].name, 'All theaters');

--- a/core/test/redux/actor_middleware_test.dart
+++ b/core/test/redux/actor_middleware_test.dart
@@ -6,6 +6,7 @@ import 'package:core/src/networking/tmdb_api.dart';
 import 'package:core/src/redux/_common/common_actions.dart';
 import 'package:core/src/redux/actor/actor_actions.dart';
 import 'package:core/src/redux/actor/actor_middleware.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -15,13 +16,13 @@ void main() {
   group('AppMiddleware', () {
     final Event event = Event(
       id: 'test',
-      actors: [
+      actors: listOf(
         Actor(name: 'Seth Ladd'),
         Actor(name: 'Eric Seidel'),
-      ],
+      ),
     );
 
-    final actorsWithAvatars = [
+    final actorsWithAvatars = listOf(
       Actor(
         name: 'Seth Ladd',
         avatarUrl: 'https://seths-profile-picture',
@@ -30,7 +31,7 @@ void main() {
         name: 'Eric Seidel',
         avatarUrl: 'https://erics-profile-picture',
       ),
-    ];
+    );
 
     final actionLog = <dynamic>[];
     final Function(dynamic) next = (dynamic action) => actionLog.add(action);

--- a/core/test/redux/actor_reducer_test.dart
+++ b/core/test/redux/actor_reducer_test.dart
@@ -2,6 +2,7 @@ import 'package:core/src/models/actor.dart';
 import 'package:core/src/redux/actor/actor_actions.dart';
 import 'package:core/src/redux/app/app_reducer.dart';
 import 'package:core/src/redux/app/app_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -10,7 +11,7 @@ void main() {
         'when called with ActorsUpdatedAction, should not modify existing actors',
         () {
       final state = AppState.initial().copyWith(
-        actorsByName: <String, Actor>{
+        actorsByName: mapFrom<String, Actor>({
           'Seth Ladd': Actor(
             name: 'Seth Ladd',
             avatarUrl: 'https://seths-avatar-url',
@@ -19,21 +20,21 @@ void main() {
             name: 'Eric Seidel',
             avatarUrl: 'https://erics-avatar-url',
           ),
-        },
+        }),
       );
 
       final reducedState = appReducer(
         state,
-        ActorsUpdatedAction([
+        ActorsUpdatedAction(listOf(
           Actor(name: 'Seth Ladd', avatarUrl: null),
           Actor(name: 'Eric Seidel', avatarUrl: null),
           Actor(name: 'Ian Hickson', avatarUrl: null),
-        ]),
+        )),
       );
 
       expect(
         reducedState.actorsByName,
-        <String, Actor>{
+        mapFrom<String, Actor>({
           'Seth Ladd': Actor(
             name: 'Seth Ladd',
             avatarUrl: 'https://seths-avatar-url',
@@ -46,7 +47,7 @@ void main() {
             name: 'Ian Hickson',
             avatarUrl: null,
           ),
-        },
+        }),
       );
     });
 
@@ -54,23 +55,23 @@ void main() {
         'when called with ReceivedActorAvatarsAction, should add urls for actors',
         () {
       final state = AppState.initial().copyWith(
-        actorsByName: <String, Actor>{
+        actorsByName: mapFrom<String, Actor>({
           'Seth Ladd': Actor(name: 'Seth Ladd', avatarUrl: null),
           'Eric Seidel': Actor(name: 'Eric Seidel', avatarUrl: null),
-        },
+        }),
       );
 
       final reducedState = appReducer(
         state,
-        ReceivedActorAvatarsAction([
+        ReceivedActorAvatarsAction(listOf(
           Actor(name: 'Seth Ladd', avatarUrl: 'https://seths-avatar-url'),
           Actor(name: 'Eric Seidel', avatarUrl: 'https://erics-avatar-url'),
-        ]),
+        )),
       );
 
       expect(
         reducedState.actorsByName,
-        <String, Actor>{
+        mapFrom<String, Actor>({
           'Seth Ladd': Actor(
             name: 'Seth Ladd',
             avatarUrl: 'https://seths-avatar-url',
@@ -79,7 +80,7 @@ void main() {
             name: 'Eric Seidel',
             avatarUrl: 'https://erics-avatar-url',
           ),
-        },
+        }),
       );
     });
   });

--- a/core/test/redux/event_middleware_test.dart
+++ b/core/test/redux/event_middleware_test.dart
@@ -9,6 +9,7 @@ import 'package:core/src/redux/event/event_actions.dart';
 import 'package:core/src/redux/event/event_middleware.dart';
 import 'package:core/src/redux/event/event_state.dart';
 import 'package:core/src/redux/theater/theater_state.dart';
+import 'package:kt_dart/kt.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -24,17 +25,17 @@ void main() {
     EventMiddleware middleware;
     MockStore mockStore;
 
-    final nowInTheatersEvents = [
+    final nowInTheatersEvents = listOf(
       Event(),
       Event(),
       Event(),
-    ];
+    );
 
-    final upcomingEvents = [
+    final upcomingEvents = listOf(
       Event(),
       Event(),
       Event(),
-    ];
+    );
 
     setUp(() {
       mockFinnkinoApi = MockFinnkinoApi();

--- a/core/test/redux/event_reducer_test.dart
+++ b/core/test/redux/event_reducer_test.dart
@@ -5,15 +5,16 @@ import 'package:core/src/redux/_common/common_actions.dart';
 import 'package:core/src/redux/event/event_actions.dart';
 import 'package:core/src/redux/event/event_reducer.dart';
 import 'package:core/src/redux/event/event_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('EventReducer', () {
     test('when receiving now in theaters events', () {
-      final events = [
+      final events = listOf(
         Event(id: 'now in'),
         Event(id: 'theaters'),
-      ];
+      );
 
       final state = EventState.initial();
       final reducedState =
@@ -24,10 +25,10 @@ void main() {
     });
 
     test('when receiving upcoming events', () {
-      final events = [
+      final events = listOf(
         Event(id: 'coming'),
         Event(id: 'soon'),
-      ];
+      );
 
       final state = EventState.initial();
       final reducedState =
@@ -41,21 +42,21 @@ void main() {
       'when called with UpdateActorsForEventAction, should update event actors when it is a now playing event',
       () {
         final state = EventState.initial().copyWith(
-          nowInTheatersEvents: [
+          nowInTheatersEvents: listOf(
             Event(id: '1'),
             Event(id: 'event-to-update'),
             Event(id: '2'),
-          ],
+          ),
         );
 
         final reducedState = eventReducer(
           state,
           UpdateActorsForEventAction(
             Event(id: 'event-to-update'),
-            [
+            listOf(
               Actor(name: 'Eric Seidel', avatarUrl: 'http://erics-avatar'),
               Actor(name: 'Seth Ladd', avatarUrl: 'http://seths-avatar'),
-            ],
+            ),
           ),
         );
 
@@ -64,7 +65,7 @@ void main() {
         expect(nowInTheatersEvents[2].actors, isNull);
 
         final updatedEvent = nowInTheatersEvents[1];
-        expect(updatedEvent.actors.length, 2);
+        expect(updatedEvent.actors.size, 2);
         expect(updatedEvent.actors[0].name, 'Eric Seidel');
         expect(updatedEvent.actors[1].name, 'Seth Ladd');
       },
@@ -74,21 +75,21 @@ void main() {
       'when called with UpdateActorsForEventAction, should update event actors when it is a upcoming event',
       () {
         final state = EventState.initial().copyWith(
-          comingSoonEvents: [
+          comingSoonEvents: listOf(
             Event(id: '1'),
             Event(id: 'event-to-update'),
             Event(id: '2'),
-          ],
+          ),
         );
 
         final reducedState = eventReducer(
           state,
           UpdateActorsForEventAction(
             Event(id: 'event-to-update'),
-            [
+            listOf(
               Actor(name: 'Eric Seidel', avatarUrl: 'http://erics-avatar'),
               Actor(name: 'Seth Ladd', avatarUrl: 'http://seths-avatar'),
-            ],
+            ),
           ),
         );
 
@@ -97,7 +98,7 @@ void main() {
         expect(comingSoonEvents[2].actors, isNull);
 
         final updatedEvent = comingSoonEvents[1];
-        expect(updatedEvent.actors.length, 2);
+        expect(updatedEvent.actors.size, 2);
         expect(updatedEvent.actors[0].name, 'Eric Seidel');
         expect(updatedEvent.actors[1].name, 'Seth Ladd');
       },

--- a/core/test/redux/event_selector_test.dart
+++ b/core/test/redux/event_selector_test.dart
@@ -26,13 +26,18 @@ void main() {
       originalTitle: 'Coming soon event #1',
       title: 'Coming soon event #1',
     );
+    final firstComingSoonEventDuplicate = Event(
+      id: 'coming-soon-1-fr',
+      originalTitle: 'Coming soon event #1',
+      title: 'Coming soon event #1 (FR)',
+    );
     final secondComingSoonEvent = Event(
       id: 'coming-soon-2',
       originalTitle: 'Coming soon event #2',
       title: 'Coming soon event #2',
     );
-    final comingSoonEvents =
-        listOf(firstComingSoonEvent, secondComingSoonEvent);
+    final comingSoonEvents = listOf(firstComingSoonEvent,
+        firstComingSoonEventDuplicate, secondComingSoonEvent);
 
     final state = AppState.initial().copyWith(
       eventState: EventState.initial().copyWith(
@@ -43,7 +48,9 @@ void main() {
 
     test('events', () {
       expect(nowInTheatersSelector(state), nowInTheatersEvents);
-      expect(comingSoonSelector(state), comingSoonEvents);
+      // without duplicates
+      expect(comingSoonSelector(state),
+          listOf(firstComingSoonEvent, secondComingSoonEvent));
     });
 
     test('events with search query', () {

--- a/core/test/redux/event_selector_test.dart
+++ b/core/test/redux/event_selector_test.dart
@@ -3,6 +3,7 @@ import 'package:core/src/models/show.dart';
 import 'package:core/src/redux/app/app_state.dart';
 import 'package:core/src/redux/event/event_selectors.dart';
 import 'package:core/src/redux/event/event_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -17,7 +18,8 @@ void main() {
       originalTitle: 'In theater event #2',
       title: 'In theater event #2',
     );
-    final nowInTheatersEvents = [firstInTheaterEvent, secondInTheaterEvent];
+    final nowInTheatersEvents =
+        listOf(firstInTheaterEvent, secondInTheaterEvent);
 
     final firstComingSoonEvent = Event(
       id: 'coming-soon-1',
@@ -29,7 +31,8 @@ void main() {
       originalTitle: 'Coming soon event #2',
       title: 'Coming soon event #2',
     );
-    final comingSoonEvents = [firstComingSoonEvent, secondComingSoonEvent];
+    final comingSoonEvents =
+        listOf(firstComingSoonEvent, secondComingSoonEvent);
 
     final state = AppState.initial().copyWith(
       eventState: EventState.initial().copyWith(
@@ -48,12 +51,12 @@ void main() {
 
       expect(
         nowInTheatersSelector(stateWithSearchQuery),
-        [secondInTheaterEvent],
+        listOf(secondInTheaterEvent),
       );
 
       expect(
         comingSoonSelector(stateWithSearchQuery),
-        [secondComingSoonEvent],
+        listOf(secondComingSoonEvent),
       );
     });
 

--- a/core/test/redux/show_middleware_test.dart
+++ b/core/test/redux/show_middleware_test.dart
@@ -10,6 +10,7 @@ import 'package:core/src/redux/show/show_middleware.dart';
 import 'package:core/src/redux/show/show_state.dart';
 import 'package:core/src/redux/theater/theater_state.dart';
 import 'package:core/src/utils/clock.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -20,7 +21,7 @@ void main() {
     final DateTime startOf2018 = DateTime(2018);
     final Theater theater = Theater(id: 'abc123', name: 'Test Theater');
     final actionLog = <dynamic>[];
-    final showCache = <DateTheaterPair, List<Show>>{};
+    final showCache = mutableMapFrom<DateTheaterPair, KtList<Show>>();
     final Function(dynamic) next = (dynamic action) {
       if (action is ReceivedShowsAction) {
         showCache[action.cacheKey] = action.shows;
@@ -91,11 +92,11 @@ void main() {
       () async {
         Clock.getCurrentTime = () => startOf2018;
         when(mockFinnkinoApi.getSchedule(theater, any))
-            .thenAnswer((_) => Future.value([
+            .thenAnswer((_) => Future.value(listOf(
                   Show(start: DateTime(2018, 02, 21)),
                   Show(start: DateTime(2018, 02, 21)),
                   Show(start: DateTime(2018, 03, 21)),
-                ]));
+                )));
 
         await middleware.call(mockStore, FetchShowsIfNotLoadedAction(), next);
 
@@ -106,9 +107,9 @@ void main() {
         expect(actionLog[1], const TypeMatcher<RequestingShowsAction>());
 
         final ReceivedShowsAction receivedShowsAction = actionLog[2];
-        expect(receivedShowsAction.shows.length, 3);
+        expect(receivedShowsAction.shows.size, 3);
 
-        final showCacheKey = showCache.keys.first;
+        final showCacheKey = showCache.keys.first();
         expect(showCacheKey.theater, theater);
         expect(showCacheKey.dateTime, startOf2018);
       },
@@ -121,11 +122,11 @@ void main() {
         Clock.getCurrentTime = () => DateTime(2018, 3);
         when(mockFinnkinoApi.getSchedule(theater, any))
             .thenAnswer((_) => Future.value(
-                  [
+                  listOf(
                     Show(start: DateTime(2018, 02, 21)),
                     Show(start: DateTime(2018, 02, 21)),
                     Show(start: DateTime(2018, 03, 21)),
-                  ],
+                  ),
                 ));
 
         // When
@@ -139,7 +140,7 @@ void main() {
         expect(actionLog[1], const TypeMatcher<RequestingShowsAction>());
 
         final ReceivedShowsAction receivedShowsAction = actionLog[2];
-        expect(receivedShowsAction.shows.length, 1);
+        expect(receivedShowsAction.shows.size, 1);
       },
     );
 
@@ -175,7 +176,7 @@ void main() {
         ShowDatesUpdatedAction action = actionLog[1];
         expect(
           action.dates,
-          [
+          listOf(
             DateTime(2018, 1, 1),
             DateTime(2018, 1, 2),
             DateTime(2018, 1, 3),
@@ -183,7 +184,7 @@ void main() {
             DateTime(2018, 1, 5),
             DateTime(2018, 1, 6),
             DateTime(2018, 1, 7),
-          ],
+          ),
         );
       },
     );
@@ -195,7 +196,7 @@ void main() {
 
         when(mockStore.state).thenReturn(_stateBoilerplate());
         when(mockFinnkinoApi.getSchedule(any, any))
-            .thenAnswer((_) => Future.value([]));
+            .thenAnswer((_) => Future.value(emptyList()));
 
         final firstDate = DateTime(2018);
         final secondDate = DateTime(2019);

--- a/core/test/redux/show_reducer_test.dart
+++ b/core/test/redux/show_reducer_test.dart
@@ -1,6 +1,7 @@
 import 'package:core/src/redux/show/show_actions.dart';
 import 'package:core/src/redux/show/show_reducer.dart';
 import 'package:core/src/redux/show/show_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -12,19 +13,19 @@ void main() {
         final reducedState = showReducer(
           initialState,
           ShowDatesUpdatedAction(
-            [
+            listOf(
               DateTime(2018, 1, 1),
               DateTime(2018, 1, 2),
-            ],
+            ),
           ),
         );
 
         expect(
           reducedState.dates,
-          [
+          listOf(
             DateTime(2018, 1, 1),
             DateTime(2018, 1, 2),
-          ],
+          ),
         );
 
         // Should also select the first date in the list

--- a/core/test/redux/show_selector_test.dart
+++ b/core/test/redux/show_selector_test.dart
@@ -6,6 +6,7 @@ import 'package:core/src/redux/app/app_state.dart';
 import 'package:core/src/redux/show/show_selectors.dart';
 import 'package:core/src/redux/show/show_state.dart';
 import 'package:core/src/redux/theater/theater_state.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -15,7 +16,7 @@ void main() {
     final secondShow =
         Show(id: 'second', title: 'Second show', originalTitle: 'Second show');
     final showWithAnotherCacheKey = Show(id: 'show-with-another-cache-key');
-    final shows = [firstShow, secondShow];
+    final shows = listOf(firstShow, secondShow);
 
     final theater = Theater(id: 'test', name: 'Test Theater');
     final date = DateTime(2018);
@@ -26,10 +27,10 @@ void main() {
       showState: ShowState.initial().copyWith(
         loadingStatus: LoadingStatus.success,
         selectedDate: date,
-        shows: {
+        shows: mapFrom({
           DateTheaterPair(date, theater): shows,
-          DateTheaterPair(null, null): [showWithAnotherCacheKey],
-        },
+          DateTheaterPair(null, null): listOf(showWithAnotherCacheKey),
+        }),
       ),
     );
 
@@ -52,23 +53,23 @@ void main() {
       expect(showsSelector(state), shows);
 
       /// When no shows found, should return empty show list instead of null.
-      expect(showsSelector(AppState.initial()), isEmpty);
+      expect(showsSelector(AppState.initial()), emptyList());
     });
 
     test('shows with search query', () {
       final stateWithSearchQuery = state.copyWith(searchQuery: 'Sec');
-      expect(showsSelector(stateWithSearchQuery), [secondShow]);
+      expect(showsSelector(stateWithSearchQuery), listOf(secondShow));
 
       /// When no shows found, should return empty show list instead of null.
       expect(
         showsSelector(
           stateWithSearchQuery.copyWith(
             showState: ShowState.initial().copyWith(
-              shows: {},
+              shows: emptyMap(),
             ),
           ),
         ),
-        isEmpty,
+        emptyList(),
       );
     });
 

--- a/core/test/redux/theater_middleware_test.dart
+++ b/core/test/redux/theater_middleware_test.dart
@@ -32,7 +32,7 @@ void main() {
 
         // Then
         final InitCompleteAction action = log.single;
-        expect(action.theaters.length, 20);
+        expect(action.theaters.size, 20);
       });
 
       test('when a persisted theater id exists, uses that as a default',

--- a/core/test/viewmodels/events_page_view_model_test.dart
+++ b/core/test/viewmodels/events_page_view_model_test.dart
@@ -1,6 +1,7 @@
 import 'package:core/src/models/event.dart';
 import 'package:core/src/models/loading_status.dart';
 import 'package:core/src/viewmodels/events_page_view_model.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -8,17 +9,17 @@ void main() {
     test('equal', () {
       final first = EventsPageViewModel(
         status: LoadingStatus.success,
-        events: [
+        events: listOf(
           Event(id: 'abc123'),
-        ],
+        ),
         refreshEvents: () {},
       );
 
       final second = EventsPageViewModel(
         status: LoadingStatus.success,
-        events: [
+        events: listOf(
           Event(id: 'abc123'),
-        ],
+        ),
         refreshEvents: () {},
       );
 
@@ -28,17 +29,17 @@ void main() {
     test('not equal', () {
       final first = EventsPageViewModel(
         status: LoadingStatus.success,
-        events: [
+        events: listOf(
           Event(id: 'abc123'),
-        ],
+        ),
         refreshEvents: () {},
       );
 
       final second = EventsPageViewModel(
         status: LoadingStatus.success,
-        events: [
+        events: listOf(
           Event(id: 'xyz456'),
-        ],
+        ),
         refreshEvents: () {},
       );
 

--- a/core/test/viewmodels/showtimes_page_view_model_test.dart
+++ b/core/test/viewmodels/showtimes_page_view_model_test.dart
@@ -1,6 +1,7 @@
 import 'package:core/src/models/loading_status.dart';
 import 'package:core/src/models/show.dart';
 import 'package:core/src/viewmodels/showtime_page_view_model.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -8,22 +9,18 @@ void main() {
     test('equal', () {
       final first = ShowtimesPageViewModel(
         status: LoadingStatus.success,
-        dates: [DateTime(2018)],
+        dates: listOf(DateTime(2018)),
         selectedDate: null,
-        shows: [
-          Show(id: 'abc123'),
-        ],
+        shows: listOf(Show(id: 'abc123')),
         changeCurrentDate: (DateTime newDate) {},
         refreshShowtimes: () {},
       );
 
       final second = ShowtimesPageViewModel(
         status: LoadingStatus.success,
-        dates: [DateTime(2018)],
+        dates: listOf(DateTime(2018)),
         selectedDate: null,
-        shows: [
-          Show(id: 'abc123'),
-        ],
+        shows: listOf(Show(id: 'abc123')),
         changeCurrentDate: (DateTime newDate) {},
         refreshShowtimes: () {},
       );
@@ -34,22 +31,18 @@ void main() {
     test('not equal', () {
       final first = ShowtimesPageViewModel(
         status: LoadingStatus.success,
-        dates: [DateTime(2018)],
+        dates: listOf(DateTime(2018)),
         selectedDate: null,
-        shows: [
-          Show(id: 'abc123'),
-        ],
+        shows: listOf(Show(id: 'abc123')),
         changeCurrentDate: (DateTime newDate) {},
         refreshShowtimes: () {},
       );
 
       final second = ShowtimesPageViewModel(
         status: LoadingStatus.success,
-        dates: [DateTime(2018)],
+        dates: listOf(DateTime(2018)),
         selectedDate: null,
-        shows: [
-          Show(id: 'xyz456'),
-        ],
+        shows: listOf(Show(id: 'xyz456')),
         changeCurrentDate: (DateTime newDate) {},
         refreshShowtimes: () {},
       );

--- a/core/test/viewmodels/theater_list_view_model_test.dart
+++ b/core/test/viewmodels/theater_list_view_model_test.dart
@@ -1,5 +1,6 @@
 import 'package:core/src/models/theater.dart';
 import 'package:core/src/viewmodels/theater_list_view_model.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -7,19 +8,19 @@ void main() {
     test('equal', () {
       final first = TheaterListViewModel(
         currentTheater: Theater(id: 'abc123', name: 'Test 1'),
-        theaters: [
+        theaters: listOf(
           Theater(id: 'abc123', name: 'Test 1'),
           Theater(id: 'xyz456', name: 'Test 2'),
-        ],
+        ),
         changeCurrentTheater: (Theater newTheater) {},
       );
 
       final second = TheaterListViewModel(
         currentTheater: Theater(id: 'abc123', name: 'Test 1'),
-        theaters: [
+        theaters: listOf(
           Theater(id: 'abc123', name: 'Test 1'),
           Theater(id: 'xyz456', name: 'Test 2'),
-        ],
+        ),
         changeCurrentTheater: (Theater newTheater) {},
       );
 
@@ -29,19 +30,19 @@ void main() {
     test('not equal', () {
       final first = TheaterListViewModel(
         currentTheater: Theater(id: 'abc123', name: 'Test 1'),
-        theaters: [
+        theaters: listOf(
           Theater(id: 'abc123', name: 'Test 1'),
           Theater(id: 'xyz456', name: 'Test 2'),
-        ],
+        ),
         changeCurrentTheater: (Theater newTheater) {},
       );
 
       final second = TheaterListViewModel(
         currentTheater: Theater(id: 'abc123', name: 'Test 1'),
-        theaters: [
+        theaters: listOf(
           Theater(id: 'efg123', name: 'Test 3'),
           Theater(id: 'hjk456', name: 'Test 4'),
-        ],
+        ),
         changeCurrentTheater: (Theater newTheater) {},
       );
 

--- a/mobile/lib/ui/event_details/actor_scroller.dart
+++ b/mobile/lib/ui/event_details/actor_scroller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:inkino/assets.dart';
 import 'package:inkino/message_provider.dart';
+import 'package:kt_dart/collection.dart';
 
 class ActorScroller extends StatelessWidget {
   const ActorScroller(this.event);
@@ -10,7 +11,7 @@ class ActorScroller extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, List<Actor>>(
+    return StoreConnector<AppState, KtList<Actor>>(
       onInit: (store) => store.dispatch(FetchActorAvatarsAction(event)),
       converter: (store) => actorsForEventSelector(store.state, event),
       builder: (_, actors) => ActorScrollerContent(actors),
@@ -20,7 +21,7 @@ class ActorScroller extends StatelessWidget {
 
 class ActorScrollerContent extends StatelessWidget {
   const ActorScrollerContent(this.actors);
-  final List<Actor> actors;
+  final KtList<Actor> actors;
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +29,7 @@ class ActorScrollerContent extends StatelessWidget {
       ListView.builder(
         padding: const EdgeInsets.only(left: 16.0),
         scrollDirection: Axis.horizontal,
-        itemCount: actors.length,
+        itemCount: actors.size,
         itemBuilder: (_, int index) {
           final actor = actors[index];
           return _ActorListItem(actor);

--- a/mobile/lib/ui/event_details/event_details_page.dart
+++ b/mobile/lib/ui/event_details/event_details_page.dart
@@ -82,9 +82,9 @@ class _EventDetailsPageState extends State<EventDetailsPage> {
   }
 
   Widget _buildActorScroller() =>
-      widget.event.actors.isNotEmpty ? ActorScroller(widget.event) : null;
+      widget.event.actors.isNotEmpty() ? ActorScroller(widget.event) : null;
 
-  Widget _buildGallery() => widget.event.galleryImages.isNotEmpty
+  Widget _buildGallery() => widget.event.galleryImages.isNotEmpty()
       ? EventGalleryGrid(widget.event)
       : Container(color: Colors.white, height: 500.0);
 
@@ -223,7 +223,6 @@ class _BackButton extends StatelessWidget {
   }
 }
 
-
 class _EventInfo extends StatelessWidget {
   _EventInfo(this.event);
   final Event event;
@@ -257,7 +256,7 @@ class _EventInfo extends StatelessWidget {
         _buildTitleAndLengthInMinutes(),
       );
 
-    if (event.directors.isNotEmpty) {
+    if (event.directors.isNotEmpty()) {
       content.add(Padding(
         padding: const EdgeInsets.only(top: 8.0),
         child: _DirectorInfo(event.director),

--- a/mobile/lib/ui/event_details/event_gallery_grid.dart
+++ b/mobile/lib/ui/event_details/event_gallery_grid.dart
@@ -59,7 +59,7 @@ class _Grid extends StatelessWidget {
       ),
       children: event.galleryImages.map((image) {
         return _GalleryImage(image.location);
-      }).toList(),
+      }).list,
     );
   }
 }

--- a/mobile/lib/ui/events/event_grid.dart
+++ b/mobile/lib/ui/events/event_grid.dart
@@ -4,6 +4,7 @@ import 'package:inkino/message_provider.dart';
 import 'package:inkino/ui/common/info_message_view.dart';
 import 'package:inkino/ui/event_details/event_details_page.dart';
 import 'package:inkino/ui/events/event_grid_item.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 class EventGrid extends StatelessWidget {
@@ -17,14 +18,14 @@ class EventGrid extends StatelessWidget {
   });
 
   final EventListType listType;
-  final List<Event> events;
+  final KtList<Event> events;
   final VoidCallback onReloadCallback;
 
   @override
   Widget build(BuildContext context) {
     final messages = MessageProvider.of(context);
 
-    if (events.isEmpty) {
+    if (events.isEmpty()) {
       return InfoMessageView(
         key: emptyViewKey,
         title: messages.allEmpty,
@@ -39,7 +40,7 @@ class EventGrid extends StatelessWidget {
 
 class _Content extends StatelessWidget {
   _Content(this.events, this.listType);
-  final List<Event> events;
+  final KtList<Event> events;
   final EventListType listType;
 
   void _openEventDetails(BuildContext context, Event event) {
@@ -76,7 +77,7 @@ class _Content extends StatelessWidget {
             crossAxisCount: crossAxisChildCount,
             childAspectRatio: 2 / 3,
           ),
-          itemCount: events.length,
+          itemCount: events.size,
           itemBuilder: _buildItem,
         ),
       ),

--- a/mobile/lib/ui/events/event_poster.dart
+++ b/mobile/lib/ui/events/event_poster.dart
@@ -26,7 +26,7 @@ class EventPoster extends StatelessWidget {
   final bool displayPlayButton;
 
   Widget _buildPlayButton() =>
-      displayPlayButton && event.youtubeTrailers.isNotEmpty
+      displayPlayButton && event.youtubeTrailers.isNotEmpty()
           ? _PlayButton(event)
           : null;
 
@@ -87,7 +87,7 @@ class _PlayButton extends StatelessWidget {
           iconSize: 42.0,
           color: Colors.white.withOpacity(0.8),
           onPressed: () {
-            final url = event.youtubeTrailers.first;
+            final url = event.youtubeTrailers.first();
             launchTrailerVideo(url);
           },
         ),

--- a/mobile/lib/ui/showtimes/showtime_date_selector.dart
+++ b/mobile/lib/ui/showtimes/showtime_date_selector.dart
@@ -24,7 +24,7 @@ class ShowtimeDateSelector extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: viewModel.dates.map((date) {
           return _DateSelectorItem(date, viewModel);
-        }).toList(),
+        }).list,
       ),
     );
   }

--- a/mobile/lib/ui/showtimes/showtime_list.dart
+++ b/mobile/lib/ui/showtimes/showtime_list.dart
@@ -6,6 +6,7 @@ import 'package:inkino/message_provider.dart';
 import 'package:inkino/ui/common/info_message_view.dart';
 import 'package:inkino/ui/common/loading_view.dart';
 import 'package:inkino/ui/showtimes/showtime_list_tile.dart';
+import 'package:kt_dart/collection.dart';
 
 class ShowtimeList extends StatefulWidget {
   static const Key emptyViewKey = Key('emptyView');
@@ -13,21 +14,21 @@ class ShowtimeList extends StatefulWidget {
 
   ShowtimeList(this.status, this.shows);
   final LoadingStatus status;
-  final List<Show> shows;
+  final KtList<Show> shows;
 
   @override
   _ShowtimeListState createState() => _ShowtimeListState();
 }
 
 class _ShowtimeListState extends State<ShowtimeList> {
-  List<Show> _shows = [];
+  KtList<Show> _shows = emptyList();
   bool _showEmptyView = false;
 
   @override
   void initState() {
     super.initState();
     _shows = widget.shows;
-    _showEmptyView = _shows.isEmpty && widget.status == LoadingStatus.success;
+    _showEmptyView = _shows.isEmpty() && widget.status == LoadingStatus.success;
   }
 
   @override
@@ -51,7 +52,7 @@ class _ShowtimeListState extends State<ShowtimeList> {
     }
 
     _showEmptyView =
-        widget.shows.isEmpty && widget.status == LoadingStatus.success;
+        widget.shows.isEmpty() && widget.status == LoadingStatus.success;
   }
 
   @override
@@ -70,7 +71,7 @@ class _ShowtimeListState extends State<ShowtimeList> {
       key: ShowtimeList.contentKey,
       child: ListView.builder(
         padding: const EdgeInsets.only(bottom: 50.0),
-        itemCount: _shows.length,
+        itemCount: _shows.size,
         itemBuilder: (BuildContext context, int index) {
           final show = _shows[index];
           return ShowtimeListTile(show);

--- a/mobile/lib/ui/theater_list/theater_list.dart
+++ b/mobile/lib/ui/theater_list/theater_list.dart
@@ -39,7 +39,7 @@ class TheaterListContent extends StatelessWidget {
     return Scrollbar(
       child: ListView.builder(
         padding: EdgeInsets.zero,
-        itemCount: viewModel.theaters.length,
+        itemCount: viewModel.theaters.size,
         itemBuilder: (BuildContext context, int index) {
           final theater = viewModel.theaters[index];
           final isSelected = viewModel.currentTheater.id == theater.id;

--- a/mobile/test/ui/event_details/event_details_page_test.dart
+++ b/mobile/test/ui/event_details/event_details_page_test.dart
@@ -10,6 +10,7 @@ import 'package:inkino/ui/events/event_poster.dart' as eventPoster;
 import 'package:inkino/ui/showtimes/showtime_list_tile.dart'
     as showtimeListTile;
 import 'package:inkino/ui/showtimes/showtime_list_tile.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:meta/meta.dart';
 
 void main() {
@@ -41,7 +42,7 @@ void main() {
 
     Future<void> _buildEventDetailsPage(
       WidgetTester tester, {
-      @required List<String> trailers,
+      @required KtList<String> trailers,
       @required Show show,
     }) {
       return provideMockedNetworkImages(() async {
@@ -53,10 +54,10 @@ void main() {
               id: '1',
               title: 'Test Title',
               genres: 'Test Genres',
-              directors: [],
-              actors: [],
+              directors: emptyList(),
+              actors: emptyList(),
               images: EventImageData.empty(),
-              galleryImages: [],
+              galleryImages: emptyList(),
               youtubeTrailers: trailers,
             ),
             show: show,
@@ -68,7 +69,7 @@ void main() {
     testWidgets(
       'when navigated to with a null show, should not display showtime information widget in the UI',
       (WidgetTester tester) async {
-        await _buildEventDetailsPage(tester, trailers: [], show: null);
+        await _buildEventDetailsPage(tester, trailers: emptyList(), show: null);
         await tester.pump();
 
         expect(find.byType(ShowtimeListTile), findsNothing);
@@ -80,7 +81,7 @@ void main() {
       (WidgetTester tester) async {
         await _buildEventDetailsPage(
           tester,
-          trailers: [],
+          trailers: emptyList(),
           show: show,
         );
 
@@ -103,7 +104,7 @@ void main() {
       (WidgetTester tester) async {
         await _buildEventDetailsPage(
           tester,
-          trailers: [],
+          trailers: emptyList(),
           show: show,
         );
 
@@ -120,7 +121,7 @@ void main() {
       (WidgetTester tester) async {
         await _buildEventDetailsPage(
           tester,
-          trailers: ['https://youtube.com/?v=test-trailer'],
+          trailers: listOf('https://youtube.com/?v=test-trailer'),
           show: show,
         );
 

--- a/mobile/test/ui/events/events_page_test.dart
+++ b/mobile/test/ui/events/events_page_test.dart
@@ -8,6 +8,7 @@ import 'package:inkino/ui/common/loading_view.dart';
 import 'package:inkino/ui/event_details/event_details_page.dart';
 import 'package:inkino/ui/events/event_grid.dart';
 import 'package:inkino/ui/events/events_page.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:mockito/mockito.dart';
 
 class MockEventsPageViewModel extends Mock implements EventsPageViewModel {}
@@ -16,18 +17,18 @@ class MockNavigatorObserver extends Mock implements NavigatorObserver {}
 
 void main() {
   group('EventGrid', () {
-    final events = [
+    final events = listOf(
       Event(
         id: '1',
         title: 'Test Title',
         genres: 'Test Genres',
-        directors: [],
-        actors: [],
+        directors: emptyList(),
+        actors: emptyList(),
         images: EventImageData.empty(),
-        youtubeTrailers: [],
-        galleryImages: [],
+        youtubeTrailers: emptyList(),
+        galleryImages: emptyList(),
       ),
-    ];
+    );
 
     MockNavigatorObserver observer;
     EventsPageViewModel mockViewModel;
@@ -55,7 +56,7 @@ void main() {
       'when there are no events, should show empty view',
       (WidgetTester tester) async {
         when(mockViewModel.status).thenReturn(LoadingStatus.success);
-        when(mockViewModel.events).thenReturn([]);
+        when(mockViewModel.events).thenReturn(emptyList());
 
         await _buildEventsPage(tester);
         await tester.pumpAndSettle();
@@ -111,7 +112,7 @@ void main() {
       'when clicking "try again" on the error view, should call refreshEvents on the view model',
       (WidgetTester tester) async {
         when(mockViewModel.status).thenReturn(LoadingStatus.error);
-        when(mockViewModel.events).thenReturn([]);
+        when(mockViewModel.events).thenReturn(emptyList());
 
         await _buildEventsPage(tester);
         await tester.pumpAndSettle();

--- a/mobile/test/ui/showtimes/showtime_date_selector_test.dart
+++ b/mobile/test/ui/showtimes/showtime_date_selector_test.dart
@@ -2,6 +2,7 @@ import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:inkino/ui/showtimes/showtime_date_selector.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:mockito/mockito.dart';
 
 class MockShowtimesPageViewModel extends Mock
@@ -9,10 +10,10 @@ class MockShowtimesPageViewModel extends Mock
 
 void main() {
   group('ShowtimeDateSelector', () {
-    final dates = [
+    final dates = listOf(
       DateTime(2018, 1, 1),
       DateTime(2018, 1, 2),
-    ];
+    );
 
     MockShowtimesPageViewModel mockViewModel;
 

--- a/mobile/test/ui/showtimes/showtimes_page_test.dart
+++ b/mobile/test/ui/showtimes/showtimes_page_test.dart
@@ -6,6 +6,7 @@ import 'package:inkino/ui/common/info_message_view.dart';
 import 'package:inkino/ui/common/loading_view.dart';
 import 'package:inkino/ui/showtimes/showtime_list.dart';
 import 'package:inkino/ui/showtimes/showtimes_page.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:mockito/mockito.dart';
 
 class MockShowtimesPageViewModel extends Mock
@@ -18,9 +19,9 @@ void main() {
     setUp(() {
       mockViewModel = MockShowtimesPageViewModel();
       when(mockViewModel.status).thenReturn(LoadingStatus.loading);
-      when(mockViewModel.dates).thenReturn([]);
+      when(mockViewModel.dates).thenReturn(emptyList());
       when(mockViewModel.selectedDate).thenReturn(DateTime(2018));
-      when(mockViewModel.shows).thenReturn([]);
+      when(mockViewModel.shows).thenReturn(emptyList());
       when(mockViewModel.refreshShowtimes).thenReturn(() {});
     });
 
@@ -38,7 +39,7 @@ void main() {
       'when there are no shows, should show empty view',
       (WidgetTester tester) async {
         when(mockViewModel.status).thenReturn(LoadingStatus.success);
-        when(mockViewModel.shows).thenReturn([]);
+        when(mockViewModel.shows).thenReturn(emptyList());
 
         await _buildShowtimesPage(tester);
         await tester.pumpAndSettle();
@@ -54,7 +55,7 @@ void main() {
     testWidgets('when shows exist, should show them',
         (WidgetTester tester) async {
       when(mockViewModel.status).thenReturn(LoadingStatus.success);
-      when(mockViewModel.shows).thenReturn([
+      when(mockViewModel.shows).thenReturn(listOf(
         Show(
           title: 'Show title',
           theaterAndAuditorium: 'Auditorium One',
@@ -62,7 +63,7 @@ void main() {
           start: DateTime(2018),
           end: DateTime(2018),
         ),
-      ]);
+      ));
 
       await _buildShowtimesPage(tester);
       await tester.pumpAndSettle();

--- a/mobile/test/ui/theater_list/theater_list_test.dart
+++ b/mobile/test/ui/theater_list/theater_list_test.dart
@@ -2,16 +2,17 @@ import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:inkino/ui/theater_list/theater_list.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:mockito/mockito.dart';
 
 class MockTheaterListViewModel extends Mock implements TheaterListViewModel {}
 
 void main() {
   group('TheaterList', () {
-    final theaters = [
+    final theaters = listOf(
       Theater(id: '1', name: 'Test Theater #1'),
       Theater(id: '2', name: 'Test Theater #2'),
-    ];
+    );
 
     MockTheaterListViewModel mockViewModel;
     bool theaterTappedCallbackCalled;
@@ -19,7 +20,7 @@ void main() {
     setUp(() {
       mockViewModel = MockTheaterListViewModel();
       when(mockViewModel.currentTheater).thenReturn(null);
-      when(mockViewModel.theaters).thenReturn([]);
+      when(mockViewModel.theaters).thenReturn(emptyList());
 
       theaterTappedCallbackCalled = false;
     });
@@ -38,7 +39,7 @@ void main() {
     testWidgets(
       'when theaters exist, should show theam in the UI',
       (WidgetTester tester) async {
-        when(mockViewModel.currentTheater).thenReturn(theaters.first);
+        when(mockViewModel.currentTheater).thenReturn(theaters.first());
         when(mockViewModel.theaters).thenReturn(theaters);
 
         await _buildTheaterList(tester);
@@ -52,7 +53,7 @@ void main() {
       'when theater tapped, should call both changeCurrentTheater and onTheaterTapped',
       (WidgetTester tester) async {
         Theater theater;
-        when(mockViewModel.currentTheater).thenReturn(theaters.first);
+        when(mockViewModel.currentTheater).thenReturn(theaters.first());
         when(mockViewModel.theaters).thenReturn(theaters);
         when(mockViewModel.changeCurrentTheater)
             .thenReturn((newTheater) => theater = newTheater);

--- a/web/lib/src/common/content_rating/content_rating_component.dart
+++ b/web/lib/src/common/content_rating/content_rating_component.dart
@@ -1,5 +1,6 @@
 import 'package:angular/angular.dart';
 import 'package:core/core.dart';
+import 'package:kt_dart/collection.dart';
 
 @Component(
   selector: 'content-rating',
@@ -17,6 +18,5 @@ class ContentRatingComponent {
   String get ageRating => show?.ageRating ?? event?.ageRating;
   String get ageRatingUrl => show?.ageRatingUrl ?? event?.ageRatingUrl;
 
-  List<ContentDescriptor> get contentDescriptors =>
-      show?.contentDescriptors ?? event?.contentDescriptors;
+  KtList<ContentDescriptor> get contentDescriptors => show?.contentDescriptors ?? event?.contentDescriptors;
 }

--- a/web/lib/src/common/content_rating/content_rating_component.html
+++ b/web/lib/src/common/content_rating/content_rating_component.html
@@ -1,2 +1,2 @@
 <img class="content-descriptor age" [src]="ageRatingUrl" [alt]="'The age rating for this movie is' + ageRating"/>
-<img class="content-descriptor" *ngFor="let cd of contentDescriptors" [alt]="cd.name" [src]="cd.imageUrl"/>
+<img class="content-descriptor" *ngFor="let cd of contentDescriptors.iter" [alt]="cd.name" [src]="cd.imageUrl"/>

--- a/web/lib/src/common/event_poster/event_poster_component.html
+++ b/web/lib/src/common/event_poster/event_poster_component.html
@@ -10,7 +10,7 @@
 <div class="event-information" *ngIf="hasDetails">
   <content-rating [event]="event"
                   size="medium"
-                  *ngIf="event.contentDescriptors.isNotEmpty">
+                  *ngIf="event.contentDescriptors.isNotEmpty()">
   </content-rating>
 
   <p><strong>{{ event.title }}</strong></p>

--- a/web/lib/src/common/theater_selector/theater_selector_dropdown_menu_component.dart
+++ b/web/lib/src/common/theater_selector/theater_selector_dropdown_menu_component.dart
@@ -1,5 +1,6 @@
 import 'package:angular/angular.dart';
 import 'package:core/core.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:redux/redux.dart';
 import 'package:web/src/common/theater_selector/theater_dropdown_controller.dart';
 
@@ -18,7 +19,7 @@ class TheaterSelectorDropdownMenuComponent {
 
   TheaterListViewModel get _viewModel => TheaterListViewModel.fromStore(_store);
   Theater get selectedTheater => _viewModel.currentTheater;
-  List<Theater> get theaters => _viewModel.theaters;
+  List<Theater> get theaters => _viewModel.theaters.list;
 
   bool get focusTrapVisible => isOpen;
   bool isOpen = false;

--- a/web/lib/src/event_details/event_details_component.html
+++ b/web/lib/src/event_details/event_details_component.html
@@ -29,19 +29,19 @@
     </div>
   </div>
 
-  <div class="section white top-shadow actor-section" *ngIf="event.actors.isNotEmpty">
+  <div class="section white top-shadow actor-section" *ngIf="event.actors.isNotEmpty()">
     <div class="centered-content">
       <h3>{{ messages.cast }}</h3>
-      <actor-scroller [actors]="event.actors"></actor-scroller>
+      <actor-scroller [actors]="event.actors.list"></actor-scroller>
     </div>
   </div>
 
-  <div class="section footer" *ngIf="event.galleryImages.isNotEmpty">
+  <div class="section footer" *ngIf="event.galleryImages.isNotEmpty()">
     <div class="centered-content">
       <h3>{{ messages.gallery }}</h3>
 
       <div class="gallery">
-        <img *ngFor="let galleryImage of event.galleryImages" [src]="galleryImage.location"
+        <img *ngFor="let galleryImage of event.galleryImages.list" [src]="galleryImage.location"
              [alt]="'A still frame from the movie ' + event.title"/>
       </div>
     </div>

--- a/web/lib/src/events/events_page_component.html
+++ b/web/lib/src/events/events_page_component.html
@@ -5,11 +5,11 @@
   </div>
 
   <loading-view [status]="viewModel.status"
-                [contentEmpty]="viewModel.events.isEmpty"
+                [contentEmpty]="viewModel.events.isEmpty()"
                 [errorMessage]="messages.errorLoadingEvents"
                 (actionButtonClicked)="viewModel.refreshEvents()">
     <div class="grid-container">
-      <event-poster *ngFor="let event of viewModel.events"
+      <event-poster *ngFor="let event of viewModel.events.list"
                     [event]="event"
                     [isComingSoon]="isDisplayingComingSoonMovies"
                     (click)="openEventDetails(event)">

--- a/web/lib/src/showtimes/showtimes_page_component.dart
+++ b/web/lib/src/showtimes/showtimes_page_component.dart
@@ -1,6 +1,7 @@
 import 'package:angular/angular.dart';
 import 'package:angular_router/angular_router.dart';
 import 'package:core/core.dart';
+import 'package:kt_dart/collection.dart';
 import 'package:redux/redux.dart';
 import 'package:web/src/common/loading_view/loading_view_component.dart';
 import 'package:web/src/common/showtime_item/showtime_item_component.dart';
@@ -35,7 +36,7 @@ class ShowtimesPageComponent implements OnActivate {
   ShowtimesPageViewModel get viewModel =>
       ShowtimesPageViewModel.fromStore(_store);
 
-  List<Show> get shows => eventFilter == null
+  KtList<Show> get shows => eventFilter == null
       ? viewModel.shows
       : showsForEventSelector(viewModel.shows, eventFilter);
 

--- a/web/lib/src/showtimes/showtimes_page_component.html
+++ b/web/lib/src/showtimes/showtimes_page_component.html
@@ -4,15 +4,15 @@
     <theater-selector></theater-selector>
   </div>
 
-  <date-selector [dates]="viewModel.dates"
+  <date-selector [dates]="viewModel.dates.list"
                  [selectedDate]="viewModel.selectedDate"
                  [newDateSelected]="viewModel.changeCurrentDate"></date-selector>
 
   <loading-view
       [status]="viewModel.status"
-      [contentEmpty]="shows.isEmpty"
+      [contentEmpty]="shows.isEmpty()"
       (actionButtonClicked)="viewModel.refreshShowtimes()">
-    <showtime-item *ngFor="let show of shows"
+    <showtime-item *ngFor="let show of shows.list"
                    [show]="show"
                    (click)="openShowDetails(show)"></showtime-item>
   </loading-view>


### PR DESCRIPTION
Adds [`kt.dart`](https://github.com/passsy/kt.dart) a [new collection library](https://medium.com/flutter-community/kt-dart-better-collections-for-your-flutter-business-logic-41886ab7883) for dart. 

- Uses `KtList` (immutable) instead of `List` mutable
- Adds a test for removing duplicate moview (the ones with same `originalTitle`)

Thanks that you wrote tests. I made it much easier to verify everything is working as before.

### Tested
- [x] core
- [x] web
- [x] mobile