### PR TITLE
update intl dep version, replace utf8 pkg usage

### DIFF
--- a/core/test/networking/finnkino_api_test.dart
+++ b/core/test/networking/finnkino_api_test.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:core/src/models/theater.dart';
 import 'package:core/src/networking/finnkino_api.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
-import 'package:utf/utf.dart';
 
 import '../parsers/event_test_seeds.ignore.dart';
 import '../parsers/show_test_seeds.ignore.dart';
@@ -31,7 +31,7 @@ void main() {
         return Future(() {
           /// Have to do this "toBytes" dance because apparently, it's hard to
           /// get the Response do the encoding with utf8 instead of Latin 1.
-          return Response.bytes(encodeUtf8(value), 200);
+          return Response.bytes(Utf8Encoder().convert(value), 200);
         });
       });
     }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   xml: ^3.0.0
   flutter_redux: ^0.5.0
-  intl: ^0.15.2
+  intl: ^0.16.1
   url_launcher: ^3.0.0
   path_provider: ^0.4.0
   key_value_store_flutter: ^1.0.0


### PR DESCRIPTION
Updates `intl` package dependency to work with Flutter SDK `1.20` and replaces usage of now discontinued utf8 package.

Fixes: #134 